### PR TITLE
Minor fixes to readme and dockerfile comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 🚀 The Pleo Analytical Engineer Challenge
 
 
-## Stewards: @team-poseidon
+## Stewards: @analytics-empowerment
 https://linear.app/pleo/project/stewards-analytical-engineer-challenge-192436dac756
 
 ## Welcome!

--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -12,19 +12,6 @@ RUN apt update \
 # Install dbt
 # RUN pip install dbt
 
-# Install Go
-#RUN cd /tmp \
-#    && wget -q https://golang.org/dl/go1.17.1.linux-amd64.tar.gz \
-#    && rm -rf /usr/local/go \
-#    && tar -C /usr/local -xzf go1.17.1.linux-amd64.tar.gz && rm /tmp/go1.17.1.linux-amd64.tar.gz \
-
-# Install Kotlin
-# RUN cd /tmp \
-#     && wget -q https://github.com/JetBrains/kotlin/releases/download/v1.5.30/kotlin-compiler-1.5.30.zip \
-#     && cd /usr/local/bin \
-#     && unzip /tmp/kotlin-compiler-1.5.30.zip \
-#     && rm /tmp/kotlin-compiler-1.5.30.zip \
-#     && apt -y install openjdk-11-jre
 
 WORKDIR /app
 COPY ./src /app


### PR DESCRIPTION
1. Update the stewards in the readme file to match codeowners (Daedalus)
2. Remove references to `golang` and `kotlin` in comments of dockerfile that are not needed for this challenge, and are causing a false positive warning in opslevel (see [slack message](https://getpleo.slack.com/archives/C02NXFCRM8U/p1676907702992719))

Note: we will do a general refresh / update of this repo before the challenge is needed later in the year