### PR TITLE
[DEVX-2447] Rollout new renovate process

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>pleo-io/renovate-config"
-  ],
-  "schedule": [
-    "on monday"
+    "github>pleo-io/renovate-config:default.json5"
   ],
   "automerge": false
 }

--- a/.github/templates.yaml
+++ b/.github/templates.yaml
@@ -1,0 +1,6 @@
+version: v34.10.1
+files:
+  - .github/workflows/renovate_dependency_management.yaml
+
+values:
+  renovateCronjobSchedule: "30 7 * * 1" # This is UTC -> At 08:30 CET / 09:30 CEST on Monday.


### PR DESCRIPTION
This PR includes all the necessary changes for this repository to use the new Renovate setup. With this new setup, you'll get the following:
* Shorten cycle time for pull requests. Thanks to enabling merge queues.
* Full control over when Renovate runs for your repo. It now runs as a scheduled (or on-demand) GH workflow on your repo.

And now, the details about the changes on this PR:
* Add the renovate_dependency_management.yaml GH workflow, which will run Renovate for this repo at a schedule, or on demand (for this we also need to bump to a recent centralized-templates version).
* Add the schedule of when Renovate will run for your repo. Our proposal is to run it once in the morning from Mon-Fri, but you can tweak it if needed.
* Remove grouping for minor and patch dependencies. With the optimized Renovate setup, where cycle time for Renovate PRs is much shorter, we don't see a need for it. Additionally, it was causing problems as some repos ended up with failing PRs that bundled dozens of dependencies, and troubleshooting them was a nightmare.
* For the repos where only 1 code reviewer approval is needed, we remove the unnecessary Kodiak setup.
* Point to the default.json5 Renovate global preset in renovate-config repo.
* Rename Renovate config from .json to .json5, so you can add explanatory comment to any custom config you need for your repo
* Clean up of the repo custom Renovate config, by removing entries that are not needed, or already present in the global Renovate preset in renovate-config.

Apart from these changes, over the next couple days, we will take care of enabling merge queues for this repo.
If you are concerned about any changes, please comment here or reach out to
[#ask-devx](https://getpleo.slack.com/archives/C030H8BMU8K).
